### PR TITLE
fix: add `types` condition to the front of the `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./index.mjs",
       "default": "./index.js"
     },


### PR DESCRIPTION
I added `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ note that this doesn't fix all of the types-related problems in this package (see the reported problems [here](https://arethetypeswrong.github.io/?p=regexpp%403.2.0)). This PR only focuses on "🐛 Used fallback condition" because that's a TypeScript bug that can't be fixed before the usage gets fixed in popular packages.